### PR TITLE
Database migration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,8 +17,3 @@
 - avoid 404s
   Route and stop endpoints should redirect to the respective searches.
   Right now /route returns a 404. It should redirect to /route/search instead.
-  
-# Database migration
-- add enum for gtfs vehicles
-- switch from using plain route type to enum
-- fix broken search for route index

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,3 +9,16 @@
 # Furter changes
 - add settings page: map switcher, theme switcher (ship more or all themes)
 - add translations
+- rewrite vehicle page to only poll database once (not easy, cause we need the trip id (which comes from the API) to fetch the database)
+- change vehicle designation: 9000s are buses, not trams
+- Fix titles:
+  The title for /routes/search should be corrected.
+  The general title should only be displayed on the home page. Custom titles should be used otherwise. If possible the general title should still be used as a fallback, but only when a custom one isn't available.
+- avoid 404s
+  Route and stop endpoints should redirect to the respective searches.
+  Right now /route returns a 404. It should redirect to /route/search instead.
+  
+# Database migration
+- add enum for gtfs vehicles
+- switch from using plain route type to enum
+- fix broken search for route index

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -7,7 +7,7 @@ await client.connect();
 
 export const handle: Handle = (async ({ event, resolve }) => {
     event.locals.stops = client.db('GTTTools').collection('stops');
-    event.locals.routes = client.db('GTTTools').collection('routes');
+    event.locals.routes = client.db('GTTTools').collection('routes-new');
     event.locals.trips = client.db('GTTTools').collection('trips');
 
     return resolve(event)

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -7,7 +7,7 @@ await client.connect();
 
 export const handle: Handle = (async ({ event, resolve }) => {
     event.locals.stops = client.db('GTTTools').collection('stops');
-    event.locals.routes = client.db('GTTTools').collection('routes-new');
+    event.locals.routes = client.db('GTTTools').collection('routes');
     event.locals.trips = client.db('GTTTools').collection('trips');
 
     return resolve(event)

--- a/src/lib/routeDB.ts
+++ b/src/lib/routeDB.ts
@@ -15,3 +15,19 @@ interface Type {
     code: number
     plain: string
 }
+
+export function getVehicleType(type: number) {
+    switch (type) {
+        case 0: return "Tram";
+        case 1: return "Metro";
+        case 2: return "Treno";
+        case 3: return "Bus";
+        case 4: return "Traghetto";
+        case 5: return "Tram";
+        case 6: return "Ovovia";
+        case 7: return "Cremagliera";
+        case 11: return "Filobus";
+        case 12: return "Monorotaia";
+    }
+    return "";
+}

--- a/src/lib/routeDB.ts
+++ b/src/lib/routeDB.ts
@@ -1,6 +1,17 @@
-export interface routeDB{
-    code: string,
-    name: string,
-    type: string,
+export interface routeDB {
+    code: Code
+    name: string
+    type: Type
     provider: string
+}
+
+interface Code {
+    internal: string
+    displayed: string
+    integer: number
+}
+
+interface Type {
+    code: number
+    plain: string
 }

--- a/src/lib/stop.ts
+++ b/src/lib/stop.ts
@@ -1,7 +1,9 @@
 //Represents a vehicle stopping by a stop. Prettified for use in app
 export interface stop {
-    route: string;
-    // routeID: string;
+    route: {
+        internal: string;
+        displayed: string;
+    }
     direction: string;
     pass: {
         time: Date;

--- a/src/lib/vehicle.ts
+++ b/src/lib/vehicle.ts
@@ -25,7 +25,6 @@ export interface vehicle {
 };
 
 export interface vehicleSearched extends vehicle {
-    route: string,  //Route on which the vehicle is in service
     trip_id: string //GTFS trip the vehicle is in service on
     db: dbData  //Data fetched from the trips and stops database collections
 }
@@ -34,6 +33,7 @@ interface dbData {
     destination: string,
     shape: number[][],
     stops: stopDB[],
+    route: { code: { internal: string, displayed: string }, name: string }
 }
 
 export interface vehicleMap {
@@ -41,13 +41,4 @@ export interface vehicleMap {
     routeID: string,
     vehicles: vehicle[],
     colour: string,
-}
-
-export function encodeRoute(code: string) {
-    if (code.includes('/')) {
-        const num = Number.parseInt(code);
-
-        return `${num}%20%2F`;
-    }
-    return code;
 }

--- a/src/routes/api/bulk-route/[route]/+server.ts
+++ b/src/routes/api/bulk-route/[route]/+server.ts
@@ -9,10 +9,10 @@ export const GET: RequestHandler = async ({ params, locals }) => {
     const routeCodes = codes.split(',');
     
     const aggr = [
-        { $match: { code: { $in: routeCodes } } },
+        { $match: { "code.internal": { $in: routeCodes } } },
         { $addFields: { weight: { $indexOfArray: [routeCodes, "$code"] } } },
         { $sort: { weight: 1 } },
-        { $project: { _id: 0, codeInt: 0 } },
+        { $project: { _id: 0 } },
     ];
 
     const res = await routes.aggregate(aggr).toArray() as routeDB[];

--- a/src/routes/api/search-route/[route]/+server.ts
+++ b/src/routes/api/search-route/[route]/+server.ts
@@ -9,12 +9,14 @@ export const GET: RequestHandler = async ({ params, locals }) => {
     const route = params.route as string;
     const aggr = [{
         $search: {
-            index: 'autocomplete_routes',
+            index: 'routes_search_migration',
             compound: {
                 should: [
-                    { autocomplete: { query: route, path: 'code' } },
+                    { autocomplete: { query: route, path: 'code.displayed', score: { boost: { value: 3 } } } },
                     { autocomplete: { query: route, path: 'name' } },
-                    { text: { query: route, path: 'type' } },
+                    { autocomplete: { query: route, path: 'type.plain' } },
+                    { text: { query: route, path: 'type.plain' } },
+                    { text: { query: route, path: 'code.displayed', score: { boost: { value: 5 } } } },
                     { range: { path: 'codeInt', gte: Number.parseInt(route), lte: Number.parseInt(route) } },
                     { text: { query: 'GTT Servizio Urbano', path: 'provider' } }
                 ]

--- a/src/routes/api/search-route/[route]/+server.ts
+++ b/src/routes/api/search-route/[route]/+server.ts
@@ -21,7 +21,7 @@ export const GET: RequestHandler = async ({ params, locals }) => {
             }
         }
     }, {
-        $project: { _id: 0, codeInt: 0 }
+        $project: { _id: 0 }
     }, {
         $limit: STOP_NUM
     }];

--- a/src/routes/api/search-route/[route]/+server.ts
+++ b/src/routes/api/search-route/[route]/+server.ts
@@ -9,7 +9,7 @@ export const GET: RequestHandler = async ({ params, locals }) => {
     const route = params.route as string;
     const aggr = [{
         $search: {
-            index: 'routes_search_migration',
+            index: 'autocomplete_routes',
             compound: {
                 should: [
                     { autocomplete: { query: route, path: 'code.displayed', score: { boost: { value: 3 } } } },

--- a/src/routes/metro/[stop]/+page.svelte
+++ b/src/routes/metro/[stop]/+page.svelte
@@ -64,7 +64,7 @@
 	{:else}
 		{#key api}
 			{#each api as pass}
-			<a href="/route/{pass.route.internal}">
+				<a href="/route/{pass.route.internal}">
 					<div class="card w-96 h-full bg-neutral hover:bg-neutral-focus text-neutral-content shadow-xl">
 						<div class="card-body p-6">
 							<h2 class="card-title mb-4 grid grid-cols-4">

--- a/src/routes/metro/[stop]/+page.svelte
+++ b/src/routes/metro/[stop]/+page.svelte
@@ -64,12 +64,12 @@
 	{:else}
 		{#key api}
 			{#each api as pass}
-				<a href="/route/METRO">
+			<a href="/route/{pass.route.internal}">
 					<div class="card w-96 h-full bg-neutral hover:bg-neutral-focus text-neutral-content shadow-xl">
 						<div class="card-body p-6">
 							<h2 class="card-title mb-4 grid grid-cols-4">
 								<span class="text-2xl text-left col-span-3">{cleanDirection(pass.direction)}</span>
-								<span class="text-sm font-light text-right">{pass.route}</span>
+								<span class="text-sm font-light text-right">{pass.route.displayed}</span>
 							</h2>
 							<div class="justify-end">
 								{#if pass.pass.length > 0}
@@ -111,13 +111,13 @@
 		{#key api}
 			{#each api as pass}
 				<div class="card card-compact w-[22rem] h-full bg-neutral hover:bg-neutral-focus text-neutral-content shadow-xl">
-					<a href="/route/METRO">
+					<a href="/route/{pass.route.internal}">
 						<div class="card-body p-6">
 							{#if pass.pass.length > 0}
 								<h2 class="card-title mb-4 grid grid-cols-4">
 									<span class="text-2xl text-left col-span-3">{cleanDirection(pass.direction)}</span>
 									<span class="text-sm font-light text-right">
-										{pass.route}
+										{pass.route.displayed}
 									</span>
 								</h2>
 								<div class="justify-end">

--- a/src/routes/route/[route]/+page.server.ts
+++ b/src/routes/route/[route]/+page.server.ts
@@ -29,15 +29,13 @@ export const load = (async ({ params, locals, depends }) => {
 
 
 async function getDB(code: string, routes: Collection<routeDB>) {
-    const route = routes.findOne({ code }, { projection: { _id: 0, provider: 0 } }) as Promise<routeDB>;
+    const route = routes.findOne({ "code.internal": code }, { projection: { _id: 0 } }) as Promise<routeDB>;
 
     return route;
 }
 
 //Return an appropriate trip info for a rotue
 async function getTrip(route: string, trips: Collection<trip>) {
-    if (route === 'METRO') route = 'M1';
-
     const aggr = [
         { $match: { route, "dates.startDate": { $lte: new Date() }, "dates.endDate": { $gte: new Date() }, [getDay()]: true } },
         { $facet: { one: [{ $match: { direction: 1 } }, { $sample: { size: 1 } }], zero: [{ $match: { direction: 0 } }, { $sample: { size: 1 } }] } },

--- a/src/routes/route/[route]/+page.svelte
+++ b/src/routes/route/[route]/+page.svelte
@@ -159,20 +159,14 @@
 </script>
 
 <svelte:head>
-	<title>Linea {data.db.type.toLowerCase()} {data.code}: informazioni in tempo reale</title>
-	<meta name="description" content="Posizioni aggiornate in tempo reale e numero di veicoli in servizio sui {data.db.type.toLowerCase()} della linea {data.code}" />
+	<title>Linea {data.db.type.plain.toLowerCase()} {data.code}: informazioni in tempo reale</title>
+	<meta name="description" content="Posizioni aggiornate in tempo reale e numero di veicoli in servizio sui {data.db.type.plain.toLowerCase()} della linea {data.code}" />
 </svelte:head>
 
 <div class="p-4 lg:grid lg:grid-cols-2">
 	<div class="flex flex-row justify-between w-full">
 		<span>
-			{#if data.code.toLowerCase() === data.db.type.toLowerCase()}
-				<h1 class="mb-4 text-xl font-semibold uppercase">
-					{data.code}
-				</h1>
-			{:else}
-				<h1 class="mb-4 text-xl font-semibold uppercase">{data.code} - {data.db.type}</h1>
-			{/if}
+			<h1 class="mb-4 text-xl font-semibold uppercase">{data.db.code.displayed} - {data.db.type.plain}</h1>
 
 			<h2 class="font-light order-3">{data.db.name}</h2>
 		</span>

--- a/src/routes/route/[route]/+page.svelte
+++ b/src/routes/route/[route]/+page.svelte
@@ -10,8 +10,11 @@
 	import { placeTiles } from '$lib/map/map';
 	import type { vehicle } from '$lib/vehicle';
 	import { favourites } from '$lib/favourites/favouriteRoutes';
+	import { getVehicleType } from '$lib/routeDB';
 
 	export let data: PageData;
+
+	const vehicleType = getVehicleType(data.db.type.code);
 
 	let numVehicles = -1;
 	let api = new Array<vehicle>();
@@ -159,14 +162,14 @@
 </script>
 
 <svelte:head>
-	<title>Linea {data.db.type.plain.toLowerCase()} {data.code}: informazioni in tempo reale</title>
-	<meta name="description" content="Posizioni aggiornate in tempo reale e numero di veicoli in servizio sui {data.db.type.plain.toLowerCase()} della linea {data.code}" />
+	<title>Linea {vehicleType.toLowerCase()} {data.code}: informazioni in tempo reale</title>
+	<meta name="description" content="Posizioni aggiornate in tempo reale e numero di veicoli in servizio sui mezzi della linea {data.code}" />
 </svelte:head>
 
 <div class="p-4 lg:grid lg:grid-cols-2">
 	<div class="flex flex-row justify-between w-full">
 		<span>
-			<h1 class="mb-4 text-xl font-semibold uppercase">{data.db.code.displayed} - {data.db.type.plain}</h1>
+			<h1 class="mb-4 text-xl font-semibold uppercase">{data.db.code.displayed} - {vehicleType}</h1>
 
 			<h2 class="font-light order-3">{data.db.name}</h2>
 		</span>

--- a/src/routes/route/search/+page.svelte
+++ b/src/routes/route/search/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Search from 'svelte-search';
 	import fetch from '$lib/proxyRequest';
-	import type { routeDB } from '$lib/routeDB';
+	import { getVehicleType, type routeDB } from '$lib/routeDB';
 	import { preloadData } from '$app/navigation';
 	import { favourites } from '$lib/favourites/favouriteRoutes';
 	import { onMount } from 'svelte';
@@ -51,7 +51,7 @@
 			<a class="my-1 card card-compact bg-base-200 btn h-fit animate-none" href="/route/{route.code.internal}">
 				<div class="card-body w-full grid grid-cols-4">
 					<span class=" text-primary card-title">{route.code.displayed}</span>
-					<span class="text-secondary col-span-3 py-1"> {route.type.plain} • {route.provider.replace('GTT Servizio ', '')}</span>
+					<span class="text-secondary col-span-3 py-1"> {getVehicleType(route.type.code)} • {route.provider.replace('GTT Servizio ', '')}</span>
 					<span class="col-span-4 text-xs italic place-self-start">{route.name}</span>
 				</div>
 			</a>
@@ -65,7 +65,7 @@
 			<a class="my-1 card card-compact bg-base-200 btn h-fit animate-none" href="/route/{route.code.internal}">
 				<div class="card-body w-full grid grid-cols-4">
 					<span class=" text-primary card-title">{route.code.displayed}</span>
-					<span class="text-secondary col-span-3 py-1"> {route.type.plain} • {route.provider.replace('GTT Servizio ', '')}</span>
+					<span class="text-secondary col-span-3 py-1"> {getVehicleType(route.type.code)} • {route.provider.replace('GTT Servizio ', '')}</span>
 					<span class="col-span-4 text-xs italic place-self-start">{route.name}</span>
 				</div>
 			</a>

--- a/src/routes/route/search/+page.svelte
+++ b/src/routes/route/search/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import Search from 'svelte-search';
 	import fetch from '$lib/proxyRequest';
-	import { encodeRoute } from '$lib/vehicle';
 	import type { routeDB } from '$lib/routeDB';
 	import { preloadData } from '$app/navigation';
 	import { favourites } from '$lib/favourites/favouriteRoutes';
@@ -49,10 +48,10 @@
 	{#if favouriteRoutes.length > 0 && value.length === 0}
 	<span class="col-span-full text-sm">Linee preferite:</span>
 		{#each favouriteRoutes as route}
-			<a class="my-1 card card-compact bg-base-200 btn h-fit animate-none" href="/route/{encodeRoute(route.code)}">
+			<a class="my-1 card card-compact bg-base-200 btn h-fit animate-none" href="/route/{route.code.internal}">
 				<div class="card-body w-full grid grid-cols-4">
-					<span class=" text-primary card-title">{route.code}</span>
-					<span class="text-secondary col-span-3 py-1"> {route.type} • {route.provider.replace('GTT Servizio ', '')}</span>
+					<span class=" text-primary card-title">{route.code.displayed}</span>
+					<span class="text-secondary col-span-3 py-1"> {route.type.plain} • {route.provider.replace('GTT Servizio ', '')}</span>
 					<span class="col-span-4 text-xs italic place-self-start">{route.name}</span>
 				</div>
 			</a>
@@ -63,7 +62,7 @@
 <div class="mx-4 lg:mx-auto py-2 lg:grid lg:grid-cols-2 lg:gap-x-4">
 	{#if routes != undefined && value.length > 0}
 		{#each routes as route}
-			<a class="my-1 card card-compact bg-base-200 btn h-fit animate-none" href="/route/{encodeRoute(route.code)}">
+			<a class="my-1 card card-compact bg-base-200 btn h-fit animate-none" href="/route/{route.code.internal}">
 				<div class="card-body w-full grid grid-cols-4">
 					<span class=" text-primary card-title">{route.code}</span>
 					<span class="text-secondary col-span-3 py-1"> {route.type} • {route.provider.replace('GTT Servizio ', '')}</span>

--- a/src/routes/route/search/+page.svelte
+++ b/src/routes/route/search/+page.svelte
@@ -64,8 +64,8 @@
 		{#each routes as route}
 			<a class="my-1 card card-compact bg-base-200 btn h-fit animate-none" href="/route/{route.code.internal}">
 				<div class="card-body w-full grid grid-cols-4">
-					<span class=" text-primary card-title">{route.code}</span>
-					<span class="text-secondary col-span-3 py-1"> {route.type} • {route.provider.replace('GTT Servizio ', '')}</span>
+					<span class=" text-primary card-title">{route.code.displayed}</span>
+					<span class="text-secondary col-span-3 py-1"> {route.type.plain} • {route.provider.replace('GTT Servizio ', '')}</span>
 					<span class="col-span-4 text-xs italic place-self-start">{route.name}</span>
 				</div>
 			</a>

--- a/src/routes/stop/[stop]/+page.svelte
+++ b/src/routes/stop/[stop]/+page.svelte
@@ -4,7 +4,6 @@
 	import type { PageData } from './$types';
 	import Loading from './loading.svelte';
 	import Timer from './timer.svelte';
-	import { encodeRoute } from '$lib/vehicle';
 	import type { stop } from '$lib/stop';
 	import { favourites } from '$lib/favourites/favouriteStops';
 
@@ -87,11 +86,11 @@
 	{:else}
 		{#key api}
 			{#each api as pass}
-				<a href="/route/{encodeRoute(pass.route)}">
+				<a href="/route/{pass.route.internal}">
 					<div class="card w-96 h-full bg-neutral hover:bg-neutral-focus text-neutral-content shadow-xl">
 						<div class="card-body p-6">
 							<h2 class="card-title mb-4 grid grid-cols-4">
-								<span class="text-2xl text-left">{pass.route}</span>
+								<span class="text-2xl text-left">{pass.route.displayed}</span>
 								<span class="text-sm font-light text-right col-span-3">
 									{pass.direction}
 								</span>
@@ -146,10 +145,10 @@
 		{#key api}
 			{#each api as pass}
 				<div class="card card-compact w-[22rem] h-full bg-neutral hover:bg-neutral-focus text-neutral-content shadow-xl">
-					<a href="/route/{encodeRoute(pass.route)}">
+					<a href="/route/{pass.route.internal}">
 						<div class="card-body p-6">
 							<h2 class="card-title mb-4 grid grid-cols-4">
-								<span class="text-2xl text-left">{pass.route}</span>
+								<span class="text-2xl text-left">{pass.route.displayed}</span>
 								<span class="text-sm font-light text-right col-span-3">
 									{pass.direction}
 								</span>

--- a/src/routes/vehicle/[vehicle]/+page.svelte
+++ b/src/routes/vehicle/[vehicle]/+page.svelte
@@ -40,7 +40,7 @@
 		clearInterval(interval);
 
 		if(api !== null) {
-			preloadData(`/route/${api.route}`);
+			preloadData(`/route/${api.db.route.code.internal}`);
 			placeTiles(L, map);
 
 			//Only place stop and shape icons if a matching trip is found
@@ -79,7 +79,7 @@
 				await invalidate('vehicle');		//Wait for page reload
 				api = await data.route.promise		//Then refresh the data
 				if(api !== null) {
-					preloadData(`/route/${api.route}`);
+					preloadData(`/route/${api.db.route.code.internal}`);
 					map.setView([api.lat, api.lon], 16);	//Only toggle if "follow" is active, TODO: add follow button
 
 					if(marker.code === api.id){
@@ -191,7 +191,7 @@
 			{#if api !== null}
 				<div class="grid grid-cols-2 md:w-1/3">
 					<div>In servizio sulla linea:</div>
-					<a class="font-mono link" href="/route/{api.route}" data-sveltekit-preload-data>{api.route}</a>
+					<a class="font-mono link" href="/route/{api.db.route.code.internal}" data-sveltekit-preload-data>{api.db.route.code.displayed}</a>
 					<div>Ultimo aggiornamento: </div>
 					<div class="font-mono"> <Counter time={api.updated}/></div>
 				</div>


### PR DESCRIPTION
Adapts the app to accomodate for the recent change in the database schema of the "routes" collection. Namely, a new ID for routes, called "internal ID" has been added. It matches the structure used by the GTT and GTFS APIs, which will be better for compatibility.

This has the added benefit of working for edge case lines which were broken before, such as "16CD" or "72 /". Therefore this PR closes #6 .

Furthermore, the vehicle type is saved both in plain text (as it was before; this is still used in search queries) as well as with a GTFS encoding. Rendering the vehicle type conditionally on the client will allow us to target it with translations, when they will be implemented in the future.